### PR TITLE
Add --no-sandbox flag to bypass Chromium sandbox issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,23 @@ Alternatively, you can set the `AWS_PROFILE` environmental variable to the name 
 
 Once you log in you can use the AWS CLI or SDKs as usual!
 
+### Troubleshooting
+
+#### Sandbox Issues
+
+If you encounter sandbox-related errors when running the tool (especially on certain Linux distributions or containerized environments), you can disable the Chromium sandbox using the `--no-sandbox` flag:
+
+    go-aws-azure-login --no-sandbox
+
+This bypasses Chromium's sandbox security feature and can resolve errors like:
+
+    panic: [launcher] Failed to get the debug url: [...] No usable sandbox! Update your kernel or see https://chromium.googlesource.com/chromium/src/+/main/docs/linux/suid_sandbox_development.md for more information
+
+You can combine this with other flags as needed:
+
+    go-aws-azure-login --profile myprofile --no-prompt --no-sandbox
+
+**Note:** Using `--no-sandbox` reduces security by disabling Chromium's sandbox. Only use this flag when necessary to resolve compatibility issues.
 
 ## Automation
 

--- a/login.go
+++ b/login.go
@@ -564,7 +564,8 @@ func login(
 	noPrompt bool,
 	isGui bool,
 	disableLeakless bool,
-	fastPass bool) {
+	fastPass bool,
+	noSandbox bool) {
 
 	profile := loadProfile(profileName)
 
@@ -580,7 +581,7 @@ func login(
 
 	loginUrl := createLoginUrl(profile.AzureAppIDUri, profile.AzureTenantID, assertionConsumerServiceURL)
 
-	saml := performLogin(loginUrl, noPrompt, profile.AzureDefaultUsername, profile.AzureDefaultPassword, profile.OktaDefaultUsername, profile.OktaDefaultPassword, isGui, disableLeakless, fastPass)
+	saml := performLogin(loginUrl, noPrompt, profile.AzureDefaultUsername, profile.AzureDefaultPassword, profile.OktaDefaultUsername, profile.OktaDefaultPassword, isGui, disableLeakless, fastPass, noSandbox)
 
 	roles := parseRolesFromSamlResponse(saml)
 
@@ -589,7 +590,7 @@ func login(
 	assumeRole(profileName, saml, rl, durationHours, awsNoVerifySsl, profile.Region)
 }
 
-func loginAll(forceRefresh bool, awsNoVerifySsl bool, noPrompt bool, isGui bool, disableLeakless bool, fastPass bool) {
+func loginAll(forceRefresh bool, awsNoVerifySsl bool, noPrompt bool, isGui bool, disableLeakless bool, fastPass bool, noSandbox bool) {
 	allProfiles := getAllProfileNames()
 
 	for _, profileName := range allProfiles {
@@ -597,7 +598,7 @@ func loginAll(forceRefresh bool, awsNoVerifySsl bool, noPrompt bool, isGui bool,
 			continue
 		}
 
-		login(profileName, awsNoVerifySsl, noPrompt, isGui, disableLeakless, fastPass)
+		login(profileName, awsNoVerifySsl, noPrompt, isGui, disableLeakless, fastPass, noSandbox)
 	}
 }
 
@@ -624,10 +625,14 @@ func createLoginUrl(appIDUri string, tenantID string, assertionConsumerServiceUR
 	return fmt.Sprintf("https://login.microsoftonline.com/%s/saml2?SAMLRequest=%s", tenantID, url.QueryEscape(samlBase64))
 }
 
-func performLogin(urlString string, noPrompt bool, defaultUserName string, defaultUserPassword *string, defaultOktaUserName *string, defaultOktaPassword *string, isGui bool, disableLeakless bool, fastpass bool) string {
+func performLogin(urlString string, noPrompt bool, defaultUserName string, defaultUserPassword *string, defaultOktaUserName *string, defaultOktaPassword *string, isGui bool, disableLeakless bool, fastpass bool, noSandbox bool) string {
 	l := launcher.New().Headless(!isGui)
 
 	l.Leakless(!disableLeakless)
+
+	if noSandbox {
+		l.NoSandbox(true)
+	}
 
 	u := l.MustLaunch()
 	browser := rod.New().ControlURL(u).MustConnect()

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ var (
 	noPrompt        bool
 	disableLeakless bool
 	fastPass        bool
+	noSandbox       bool
 )
 
 func init() {
@@ -38,6 +39,8 @@ func init() {
 		disableLeaklessUsage        = "Disable leakless if you are having issues with it"
 		fastPassDefaultValue        = false
 		fastPassUsage               = "Use Okta FastPass verification"
+		noSandboxDefaultValue       = false
+		noSandboxUsage              = "Disable Chromium sandbox (use when getting sandbox-related errors)"
 	)
 
 	flag.StringVar(&profile, "profile", profileDefaultValue, profileUsage)
@@ -54,6 +57,7 @@ func init() {
 	flag.BoolVar(&noPrompt, "no-prompt", noPromptDefaultValue, noPromptUsage)
 	flag.BoolVar(&disableLeakless, "disable-leakless", disableLeaklessDefaultValue, disableLeaklessUsage)
 	flag.BoolVar(&fastPass, "fastpass", fastPassDefaultValue, fastPassUsage)
+	flag.BoolVar(&noSandbox, "no-sandbox", noSandboxDefaultValue, noSandboxUsage)
 
 	flag.Parse()
 	if flag.NArg() > 0 {
@@ -79,9 +83,9 @@ func main() {
 		configureProfile(profileName)
 	} else {
 		if allProfiles {
-			loginAll(forceRefresh, noVerifySSL, noPrompt, isGui, disableLeakless, fastPass)
+			loginAll(forceRefresh, noVerifySSL, noPrompt, isGui, disableLeakless, fastPass, noSandbox)
 		} else {
-			login(profileName, noVerifySSL, noPrompt, isGui, disableLeakless, fastPass)
+			login(profileName, noVerifySSL, noPrompt, isGui, disableLeakless, fastPass, noSandbox)
 		}
 	}
 


### PR DESCRIPTION
# Add `--no-sandbox` flag to bypass Chromium sandbox issues

## Summary
Added a new `--no-sandbox` command-line flag to disable Chromium's sandbox when running the browser automation. This resolves compatibility issues on certain Linux distributions and containerized environments where the sandbox cannot be properly initialized.

## Problem Solved
Fixes the following error that occurs on systems with incompatible kernel configurations:
```
panic: [launcher] Failed to get the debug url: [2970516:2970516:0617/141128.288107:FATAL:zygote_host_impl_linux.cc(126)] No usable sandbox! Update your kernel or see https://chromium.googlesource.com/chromium/src/+/main/docs/linux/suid_sandbox_development.md for more information on developing with the SUID sandbox. If you want to live dangerously and need an immediate workaround, you can try using --no-sandbox.
```

## Changes Made

### Code Changes
- **`main.go`**: Added `noSandbox` boolean variable and flag registration
- **`login.go`**: Updated function signatures to pass the `noSandbox` parameter through the call chain:
  - `login()` function
  - `loginAll()` function  
  - `performLogin()` function
- **`login.go`**: Added conditional launcher configuration: `l.NoSandbox(true)` when flag is enabled

### Documentation
- **`README.md`**: Added new "Troubleshooting" section with sandbox issue documentation

## Usage
```bash
# Basic usage with no-sandbox flag
go-aws-azure-login --no-sandbox

# Combined with other flags
go-aws-azure-login --profile myprofile --no-prompt --no-sandbox
```

## Security Note
The `--no-sandbox` flag reduces security by disabling Chromium's sandbox. Users are advised to only use this flag when necessary to resolve compatibility issues, as documented in the README.

## Testing
- ✅ Builds successfully
- ✅ Flag appears in help output
- ✅ Flag is properly parsed without errors
- ✅ Maintains backward compatibility
